### PR TITLE
fix nested `expand_targetlist` directories

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,5 @@ hyperframe
 selenium-wire
 blinker==1.7.0
 webdriver-manager
-gdown
 memory-profiler
 psutil

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,7 @@ h2
 hyperframe
 selenium-wire
 blinker==1.7.0
+helium
 webdriver-manager
 memory-profiler
 psutil

--- a/setup.sh
+++ b/setup.sh
@@ -61,8 +61,8 @@ else
 fi
 
 # Install additional packages
-conda run -n "$ENV_NAME" python -m pip install helium
-conda run -n "$ENV_NAME" pip install --upgrade pip setuptools wheel
+conda run -n "$ENV_NAME" python -m pip install -r requirements.txt
+#conda run -n "$ENV_NAME" pip install --upgrade pip setuptools wheel
 
 ## Download models
 echo "Going to the directory of package Phishpedia in Conda environment myenv."

--- a/setup.sh
+++ b/setup.sh
@@ -112,6 +112,34 @@ else
   download_with_retry 1fr5ZxBKyDiNZ_1B6rRAfZbAHBBoUjZ7I expand_targetlist.zip
 fi
 
+# Unzip the file
+unzip expand_targetlist.zip -d expand_targetlist
+
+# Change to the extracted directory
+cd expand_targetlist || exit 1  # Exit if the directory doesn't exist
+
+# Check if there's a nested 'expand_targetlist/' directory
+if [ -d "expand_targetlist" ]; then
+  echo "Nested directory 'expand_targetlist/' detected. Moving contents up..."
+
+  # Enable dotglob to include hidden files
+  shopt -s dotglob
+
+  # Move everything from the nested directory to the current directory
+  mv expand_targetlist/* .
+
+  # Disable dotglob to revert back to normal behavior
+  shopt -u dotglob
+
+  # Remove the now-empty nested directory
+  rmdir expand_targetlist
+  cd ../
+else
+  echo "No nested 'expand_targetlist/' directory found. No action needed."
+fi
+
+echo "Extraction completed successfully."
+
 # Domain map
 if [ -f "domain_map.pkl" ]; then
   echo "Domain map exists... skip"

--- a/setup.sh
+++ b/setup.sh
@@ -62,7 +62,7 @@ fi
 
 # Install additional packages
 conda run -n "$ENV_NAME" python -m pip install -r requirements.txt
-#conda run -n "$ENV_NAME" pip install --upgrade pip setuptools wheel
+conda run -n "$ENV_NAME" pip install --upgrade pip setuptools wheel
 
 ## Download models
 echo "Going to the directory of package Phishpedia in Conda environment myenv."


### PR DESCRIPTION
This commit reproduces the way Phishpedia unzips and checks whether the directory `expand_targetlist` is nested within a similarily-named folder. If that is the case, it move files within  `expand_targetlist` to the upper layer, and does nothing otherwise.