### PR TITLE
Fix CI: pin torch to a version with a prebuilt detectron2; drop unuse…

### DIFF
--- a/scripts/auto_install_detectron2.py
+++ b/scripts/auto_install_detectron2.py
@@ -16,6 +16,13 @@ import urllib.error
 PREBUILT_BASE_URL = "https://github.com/MiroPsota/torch_packages_builder/releases/download"
 PREBUILT_INDEX_URL = "https://miropsota.github.io/torch_packages_builder/detectron2/"
 
+# Pin PyTorch to a version that has a matching prebuilt detectron2 wheel
+# (see TORCH_VERSION_COMMIT_MAP below). Without a pin, pip installs the latest
+# torch, which often has no prebuilt detectron2 yet and forces a from-source
+# compile (which needs git and a toolchain and is slow/fragile in CI).
+TORCH_VERSION = "2.9.1"
+TORCHVISION_VERSION = "0.24.1"
+
 # List of known commit hashes (sorted by priority, newer ones first)
 KNOWN_COMMIT_HASHES = ['fd27788', '864913f', '18f6958', '2a420ed', '']
 
@@ -116,11 +123,14 @@ def install_pytorch(info):
     
     print("Installing PyTorch...")
     
+    torch_pkg = f'torch=={TORCH_VERSION}'
+    torchvision_pkg = f'torchvision=={TORCHVISION_VERSION}'
+
     if os_name == 'Darwin':  # macOS
         # macOS only supports CPU version (or MPS for Apple Silicon)
         install_cmd = [
             sys.executable, '-m', 'pip', 'install',
-            'torch', 'torchvision'
+            torch_pkg, torchvision_pkg
         ]
     elif has_cuda and cuda_version:
         # Choose appropriate PyTorch based on CUDA version
@@ -139,14 +149,14 @@ def install_pytorch(info):
         
         install_cmd = [
             sys.executable, '-m', 'pip', 'install',
-            'torch', 'torchvision',
+            torch_pkg, torchvision_pkg,
             '--index-url', f'https://download.pytorch.org/whl/{cuda_tag}'
         ]
     else:
         # CPU version
         install_cmd = [
             sys.executable, '-m', 'pip', 'install',
-            'torch', 'torchvision',
+            torch_pkg, torchvision_pkg,
             '--index-url', 'https://download.pytorch.org/whl/cpu'
         ]
     

--- a/src/phishintention/networks/bit_backbone.py
+++ b/src/phishintention/networks/bit_backbone.py
@@ -19,8 +19,6 @@ are shared by the CRP classifier networks (``crp_models``) and the OCR-aided
 Siamese network (``siamese_models``).
 """
 
-from collections import OrderedDict
-
 import torch
 import torch.nn as nn
 import torch.nn.functional as F


### PR DESCRIPTION
…d import

- auto_install_detectron2.py installed unpinned torch, so CI pulled torch 2.12.0 which has no prebuilt detectron2 wheel; the from-source fallback then failed in the Docker image (no git). Pin torch==2.9.1 / torchvision==0.24.1 (2.9.1 is in TORCH_VERSION_COMMIT_MAP and its prebuilt detectron2 cpu wheel exists), so the prebuilt wheel is used and no compilation is needed.
- Remove unused 'collections.OrderedDict' import in bit_backbone.py (ruff F401).